### PR TITLE
Errors merging for setError method.

### DIFF
--- a/src/Schema.js
+++ b/src/Schema.js
@@ -144,11 +144,15 @@ class Schema {
     }
 
     setError(key, error, index) {
-        if (!this.errors[key]) this.errors[key] = [];
+        if (!this.errors[key]) {
+            this.errors[key] = [];
+        }
+
         if (index > -1) {
             this.errors[key][index] = mergeErrors(this.errors[key][index], error);
             return;
         }
+
         this.errors[key].push(error);
     }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -78,7 +78,7 @@ export const getErrorIndexFromKeys = (keys) => {
     return -1;
 };
 
-const hasNoProps = (obj) => {
+const isObjectWithoutProps = (obj) => {
     if (obj === null) {
         return true;
     }
@@ -115,7 +115,7 @@ const mergeErrorsLists = (a, b) => {
 
     for (let i = 0; i < maxLength; i += 1) {
         const value = b[i] || a[i];
-        if (value && !hasNoProps(value)) {
+        if (value && !isObjectWithoutProps(value)) {
             merged[i] = value;
         }
     }
@@ -127,10 +127,10 @@ const mergeObjectsErrors = (currentErrors, nextErrors) => {
     const errors = {};
     const errorKeys = new Set();
 
-    if (!hasNoProps(currentErrors)) {
+    if (!isObjectWithoutProps(currentErrors)) {
         Object.keys(currentErrors).forEach(key => errorKeys.add(key));
     }
-    if (!hasNoProps(nextErrors)) {
+    if (!isObjectWithoutProps(nextErrors)) {
         Object.keys(nextErrors).forEach(key => errorKeys.add(key));
     }
 
@@ -144,7 +144,7 @@ const mergeObjectsErrors = (currentErrors, nextErrors) => {
 };
 
 export const mergeErrors = (currentErrors = {}, nextErrors = {}) => {
-    if (hasNoProps(currentErrors) && hasNoProps(nextErrors)) {
+    if (isObjectWithoutProps(currentErrors) && isObjectWithoutProps(nextErrors)) {
         return {};
     }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -59,9 +59,8 @@ export const getFunctionName = (type) => {
     return typeName;
 };
 
-/* eslint-disable */
+// eslint-disable-next-line no-self-compare
 export const isNaN = value => typeof value === 'number' && value !== value;
-/* eslint-enable */
 
 export const removeFirstKeyIfNumber = (keys) => {
     const firstKey = parseInt(keys[0], 10);
@@ -79,21 +78,79 @@ export const getErrorIndexFromKeys = (keys) => {
     return -1;
 };
 
-export const mergeErrors = (currentErrors = {}, nextErrors = {}) => {
+const hasNoProps = (obj) => {
+    if (obj === null) {
+        return true;
+    }
+
+    return typeof obj === 'object' &&
+        !Array.isArray(obj) &&
+        Object.keys(obj).length === 0;
+};
+
+const isArrayable = src =>
+    Array.isArray(src) ||
+    typeof src === 'string' ||
+    typeof src === 'undefined';
+
+const castAsArray = (src) => {
+    if (src === null) {
+        return [];
+    }
+    if (Array.isArray(src)) {
+        return src;
+    }
+    if (typeof src === 'string') {
+        return [src];
+    }
+    if (Object.keys(src).length) {
+        return [src];
+    }
+    return [];
+};
+
+const mergeErrorsLists = (a, b) => {
+    const merged = [];
+    const maxLength = Math.max(a.length, b.length);
+
+    for (let i = 0; i < maxLength; i += 1) {
+        const value = b[i] || a[i];
+        if (value && !hasNoProps(value)) {
+            merged[i] = value;
+        }
+    }
+
+    return merged;
+};
+
+const mergeObjectsErrors = (currentErrors, nextErrors) => {
     const errors = {};
     const errorKeys = new Set();
-    if (typeof nextErrors === 'string') {
-        if (!Array.isArray(currentErrors)) {
-            return [nextErrors];
-        }
-        return [...currentErrors, nextErrors];
+
+    if (!hasNoProps(currentErrors)) {
+        Object.keys(currentErrors).forEach(key => errorKeys.add(key));
     }
-    Object.keys(currentErrors).forEach(key => errorKeys.add(key));
-    Object.keys(nextErrors).forEach(key => errorKeys.add(key));
+    if (!hasNoProps(nextErrors)) {
+        Object.keys(nextErrors).forEach(key => errorKeys.add(key));
+    }
+
     errorKeys.forEach((key) => {
         const current = currentErrors[key] || [];
         const next = nextErrors[key] || [];
-        errors[key] = [...wrapToArray(current, true), ...wrapToArray(next, true)];
+        errors[key] = mergeErrors(current, next);
     });
+
     return errors;
+};
+
+export const mergeErrors = (currentErrors = {}, nextErrors = {}) => {
+    if (hasNoProps(currentErrors) && hasNoProps(nextErrors)) {
+        return {};
+    }
+
+    if (isArrayable(currentErrors) || isArrayable(nextErrors)) {
+        return mergeErrorsLists(castAsArray(currentErrors), castAsArray(nextErrors));
+    }
+
+    return mergeObjectsErrors(currentErrors, nextErrors);
 };

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -258,12 +258,21 @@ describe('helpers', () => {
 
             expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
         });
-        it('should override current errors of next is a string', () => {
+        it('should override current errors if next is a string', () => {
             const currentErrors = {
                 foo: ['foo 1', 'foo 2'],
             };
             const nextErrors = 'bar';
             const expected = ['bar'];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should override current errors if next is an array of strings', () => {
+            const currentErrors = {
+                foo: ['foo 1', 'foo 2'],
+            };
+            const nextErrors = ['bar 1'];
+            const expected = ['bar 1'];
 
             expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
         });
@@ -329,6 +338,22 @@ describe('helpers', () => {
             const currentErrors = [];
             const nextErrors = { foo: 'foo 1' };
             const expected = [{ foo: 'foo 1' }];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should return next errors wrapped in array if one of previous params is an array', () => {
+            const currentErrors = [{
+                foo: ['foo 1'],
+            }];
+            const nextErrors = { foo: 'foo 2' };
+            const expected = [{ foo: 'foo 2' }];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should replace one of current errors if current is an array of strings and next is an object', () => {
+            const currentErrors = ['foo 1', 'foo 2'];
+            const nextErrors = { foo: 'foo 3' };
+            const expected = [{ foo: 'foo 3' }, 'foo 2'];
 
             expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
         });

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -229,36 +229,115 @@ describe('helpers', () => {
         });
     });
     describe('mergeErrors', () => {
-        it('should return error with 2 keys', () => {
-            const currentErrors = { foo: ['foo error 1', 'foo error 2'] };
-            const nextErrors = { bar: ['bar error 1', 'bar error 2'] };
-            expect(mergeErrors(currentErrors, nextErrors)).toEqual({
-                foo: ['foo error 1', 'foo error 2'],
-                bar: ['bar error 1', 'bar error 2'],
-            });
+        it('should merge objects with props as arrays of errors', () => {
+            const currentErrors = {
+                foo: ['foo 1', 'foo 2'],
+            };
+            const nextErrors = {
+                bar: ['bar 1', 'bar 2'],
+            };
+            const expected = {
+                foo: ['foo 1', 'foo 2'],
+                bar: ['bar 1', 'bar 2'],
+            };
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
         });
-        it('should return error with 2 keys', () => {
-            const currentErrors = { foo: ['foo error 1', 'foo error 2'], bar: ['bar error 3'] };
-            const nextErrors = { bar: ['bar error 1', 'bar error 2'] };
-            expect(mergeErrors(currentErrors, nextErrors)).toEqual({
-                foo: ['foo error 1', 'foo error 2'],
-                bar: ['bar error 3', 'bar error 1', 'bar error 2'],
-            });
+        it('should merge list of errors with given props', () => {
+            const currentErrors = {
+                foo: ['foo 1', 'foo 2'],
+                bar: ['bar 3'],
+            };
+            const nextErrors = {
+                bar: ['bar 1', 'bar 2'],
+            };
+            const expected = {
+                foo: ['foo 1', 'foo 2'],
+                bar: ['bar 1', 'bar 2'],
+            };
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
         });
-        it('should return empty object if errors are undefined', () => {
+        it('should override current errors of next is a string', () => {
+            const currentErrors = {
+                foo: ['foo 1', 'foo 2'],
+            };
+            const nextErrors = 'bar';
+            const expected = ['bar'];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should not override current errors if next is an empty object', () => {
+            const currentErrors = {
+                foo: ['foo 1', 'foo 2'],
+            };
+            const nextErrors = {};
+            const expected = { ...currentErrors };
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should return an empty object if errors are undefined', () => {
             const currentErrors = undefined;
             const nextErrors = undefined;
-            expect(mergeErrors(currentErrors, nextErrors)).toEqual({});
+            const expected = {};
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
         });
-        it('should return array with errors if next error is string', () => {
-            const currentErrors = ['foo error'];
-            const nextErrors = 'bar error';
-            expect(mergeErrors(currentErrors, nextErrors)).toEqual(['foo error', 'bar error']);
+        it('should return an empty object if errors are nulls', () => {
+            const currentErrors = null;
+            const nextErrors = null;
+            const expected = {};
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
         });
-        it('should return array with error if next error is string and current error is undefined', () => {
+        it('should return an empty object if errors are null and undefined respectively', () => {
+            const currentErrors = null;
+            const nextErrors = undefined;
+            const expected = {};
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should return an array with errors if next error is string and current is an array', () => {
+            const currentErrors = ['foo'];
+            const nextErrors = 'bar';
+            const expected = ['bar'];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should return an array with error if next is a string and current is undefined', () => {
             const currentErrors = undefined;
-            const nextErrors = 'bar error';
-            expect(mergeErrors(currentErrors, nextErrors)).toEqual(['bar error']);
+            const nextErrors = 'bar';
+            const expected = ['bar'];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should return an array with error if next is null and current is a string', () => {
+            const currentErrors = 'foo';
+            const nextErrors = null;
+            const expected = ['foo'];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should return an array with error if next is a string and current is null', () => {
+            const currentErrors = null;
+            const nextErrors = 'bar';
+            const expected = ['bar'];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should return next errors as array if current is an array', () => {
+            const currentErrors = [];
+            const nextErrors = { foo: 'foo 1' };
+            const expected = [{ foo: 'foo 1' }];
+
+            expect(mergeErrors(currentErrors, nextErrors)).toEqual(expected);
+        });
+        it('should keep errors indices', () => {
+            const currErrors = ['foo 1', undefined, 'foo 3', undefined, undefined];
+            const nextErrors = ['bar 1', undefined, undefined, 'bar 4'];
+            const expected = ['bar 1', undefined, 'foo 3', 'bar 4'];
+
+            expect(mergeErrors(currErrors, nextErrors)).toEqual(expected);
         });
     });
 });


### PR DESCRIPTION
Added a bunch of test cases for **mergeErrors** helper, and improved it a bit. There were some cases (with nested lists especially) that previous implementation did not handle properly.